### PR TITLE
sanitize output similar to PHP's htmlspecialchars() to avoid display …

### DIFF
--- a/index.php
+++ b/index.php
@@ -124,7 +124,7 @@
 			if( $element.hasClass('expandedMessage') == false)
 			{
 				// Add new tr with full message + add class
-				$element.after('<tr><td colspan="7" class="expandedMessage"><div class="increase-font-size">' + row.Message + '</div></td></tr>');
+				$element.after('<tr><td colspan="7" class="expandedMessage"><div class="increase-font-size">' + escapeHtml(row.Message) + '</div></td></tr>');
 				$element.addClass('expandedMessage');
 			}
 			else
@@ -271,7 +271,7 @@
 	
 	function MessageFormat(value)
 	{
-		return value;
+		return escapeHtml(value);
 	}
 	
 	function idFormat(value, row)
@@ -316,6 +316,15 @@
 		}
 	}
 	
+        function escapeHtml(text) {
+                return text
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        }
+
 	</script>
   
  <body>


### PR DESCRIPTION
…errors and possibly mitigate some evilness. most likely needs more work.

without this fix, rendering logs from an email server in bootstrap-rsyslog-ui will loose information, since an \<email@addre.ss\> will be rendered as a HTML tag. The side effect is that it provides some crude XSS protection as well. But as noted in the commit message, will most likely need some more work.

  